### PR TITLE
include part after hash in pasted URL

### DIFF
--- a/script.js
+++ b/script.js
@@ -58,7 +58,7 @@ jQuery(function () {
          */
         function getLocal(pasted) {
             const url = new URL(pasted);
-            const path = url.pathname;
+            const path = url.pathname.concat(url.hash);
             const href = url.href;
 
             // no URL rewriting


### PR DESCRIPTION
fixes bug 1 , also see https://forum.dokuwiki.org/d/19225-link-to-sections and https://developer.mozilla.org/en-US/docs/Web/API/URL/hash
checked and worked...